### PR TITLE
Removed Call to Deprecated Function

### DIFF
--- a/ext/libsvm_wrap.cxx
+++ b/ext/libsvm_wrap.cxx
@@ -1704,7 +1704,7 @@ SWIG_AsCharPtrAndSize(VALUE obj, char** cptr, size_t* psize, int *alloc)
     
 
 
-    char *cstr = STR2CSTR(obj);
+    char *cstr = StringValuePtr(obj);
     
     size_t size = RSTRING_LEN(obj) + 1;
     if (cptr)  {


### PR DESCRIPTION
This solves issue #7
There's a deprecated function call (STR2CSTR) that needs to be changed to StringValuePtr.
